### PR TITLE
increase timeout to 30sec for Mega

### DIFF
--- a/FCU_EFIS/Community/boards/gagagu_fcu_efis_mega.board.json
+++ b/FCU_EFIS/Community/boards/gagagu_fcu_efis_mega.board.json
@@ -4,7 +4,7 @@
       "Device": "atmega2560",
       "BaudRates": [ "115200" ],
       "Programmer": "wiring",
-      "Timeout": 15000
+      "Timeout": 30000
     },
     "Connection": {
       "ConnectionDelay": 2000,


### PR DESCRIPTION
## Description of changes

Timeout time is increased to 30sec for the Mega board as uploading this big firmware takes more time as the stock one.
