### PR TITLE
fixes timeout error when flashing the FW

### DIFF
--- a/FCU_EFIS/Community/boards/gagagu_fcu_efis_mega.board.json
+++ b/FCU_EFIS/Community/boards/gagagu_fcu_efis_mega.board.json
@@ -1,502 +1,504 @@
 {
-    "$schema": "./mfboard.schema.json",
-    "AvrDudeSettings": {
-      "Device": "atmega2560",
-      "BaudRates": [ "115200" ],
-      "Programmer": "wiring",
-      "Timeout": 30000
-    },
-    "Connection": {
-      "ConnectionDelay": 2000,
-      "ExtraConnectionRetry": false,
-      "ForceResetOnFirmwareUpdate": false,
-      "DelayAfterFirmwareUpdate": 2000,
-      "DtrEnable": true,
-      "MessageSize": 90,
-      "EEPROMSize": 1496
-    },
-    "HardwareIds": [
-      "^VID_2341&PID_0010",
-      "^VID_2341&PID_0042",
-      "^VID_8087&PID_0024",
-      "^VID_1A86&PID_7523",
-      "^VID_2A03&PID_0042",
-      "^VID_0403&PID_6001",
-      "^VID_0403\\+PID_6001\\+.+",
-      "^VID_2A03&PID_0010",
-      "^VID_2341&PID_0210",
-      "^VID_2341&PID_0242",
-      "^VID_10C4&PID_EA60",
-      "^VID_2341&PID_0044",
-      "^VID_3343&PID_0042",
-      "^VID_04D9&PID_B534"
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Device": "atmega2560",
+    "BaudRates": [
+      "115200"
     ],
-    "Info": {
-      "CanInstallFirmware": true,
-      "CanResetBoard": true,
-      "DelayAfterFirmwareUpdate": 0,
-      "FirmwareBaseName": "gagagu_fcu_efis_mega",
-      "FirmwareExtension": "hex",
-      "LatestFirmwareVersion": "0.9.2",
-      "FriendlyName": "Elral Gagagu FCU-EFIS Mega",
-      "MobiFlightType": "Gagagu FCU/EFIS Mega",
-      "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",
-      "CustomDeviceTypes": [
-        "GAGAGU_FCU-EFIS"
-      ],
-      "Community": {
-        "Project": "Gagagu FCU_EFIS",
-        "Website": "https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs",
-        "Docs": "https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs",
-        "Support": "https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs"
-      },
-      "DeviceConfigs": [
-        {
-          "Name": "FCU/EFIS Display",
-          "Description": "FCU and EFIS display with 7 Oled's",
-          "File": "Gagagu FCU-EFIS.mfmc"
-        }
-      ]
+    "Programmer": "wiring",
+    "Timeout": 25000
+  },
+  "Connection": {
+    "ConnectionDelay": 2000,
+    "ExtraConnectionRetry": false,
+    "ForceResetOnFirmwareUpdate": false,
+    "DelayAfterFirmwareUpdate": 2000,
+    "DtrEnable": true,
+    "MessageSize": 90,
+    "EEPROMSize": 1496,
+    "TimeoutForFirmwareUpdate": 25000
+  },
+  "HardwareIds": [
+    "^VID_2341&PID_0010",
+    "^VID_2341&PID_0042",
+    "^VID_8087&PID_0024",
+    "^VID_1A86&PID_7523",
+    "^VID_2A03&PID_0042",
+    "^VID_0403&PID_6001",
+    "^VID_0403\\+PID_6001\\+.+",
+    "^VID_2A03&PID_0010",
+    "^VID_2341&PID_0210",
+    "^VID_2341&PID_0242",
+    "^VID_10C4&PID_EA60",
+    "^VID_2341&PID_0044",
+    "^VID_3343&PID_0042",
+    "^VID_04D9&PID_B534"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "CanResetBoard": true,
+    "DelayAfterFirmwareUpdate": 0,
+    "FirmwareBaseName": "gagagu_fcu_efis_mega",
+    "FirmwareExtension": "hex",
+    "LatestFirmwareVersion": "0.9.2",
+    "FriendlyName": "Elral Gagagu FCU-EFIS Mega",
+    "MobiFlightType": "Gagagu FCU/EFIS Mega",
+    "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",
+    "CustomDeviceTypes": [
+      "GAGAGU_FCU-EFIS"
+    ],
+    "Community": {
+      "Project": "Gagagu FCU_EFIS",
+      "Website": "https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs",
+      "Docs": "https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs",
+      "Support": "https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs"
     },
-    "ModuleLimits": {
-      "MaxAnalogInputs": 16,
-      "MaxInputShifters": 4,
-      "MaxButtons": 68,
-      "MaxEncoders": 20,
-      "MaxLcdI2C": 2,
-      "MaxLedSegments": 4,
-      "MaxOutputs": 40,
-      "MaxServos": 10,
-      "MaxShifters": 4,
-      "MaxSteppers": 10,
-      "MaxInputMultiplexer": 4,
-      "MaxCustomDevices": 5
-    },
-    "Pins": [
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 2
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 3
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 4
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 5
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 6
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 7
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 8
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 9
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 10
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 11
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 12
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 13
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 14
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 15
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 16
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 17
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 18
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 19
-      },
-      {
-        "isAnalog": false,
-        "isPWM": false,
-        "isI2C": true,
-        "Pin": 20
-      },
-      {
-        "isAnalog": false,
-        "isPWM": false,
-        "isI2C": true,
-        "Pin": 21
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 22
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 23
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 24
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 25
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 26
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 27
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 28
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 29
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 30
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 31
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 32
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 33
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 34
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 35
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 36
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 37
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 38
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 39
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 40
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 41
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 42
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 43
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 44
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 45
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": true,
-        "Pin": 46
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 47
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 48
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 49
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 50
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 51
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 52
-      },
-      {
-        "isAnalog": false,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 53
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 54,
-        "Name": "A0"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 55,
-        "Name": "A1"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 56,
-        "Name": "A2"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 57,
-        "Name": "A3"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 58,
-        "Name": "A4"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 59,
-        "Name": "A5"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 60,
-        "Name": "A6"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 61,
-        "Name": "A7"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 62,
-        "Name": "A8"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 63,
-        "Name": "A9"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 64,
-        "Name": "A10"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 65,
-        "Name": "A11"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 66,
-        "Name": "A12"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 67,
-        "Name": "A13"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 68,
-        "Name": "A14"
-      },
-      {
-        "isAnalog": true,
-        "isI2C": false,
-        "isPWM": false,
-        "Pin": 69,
-        "Name": "A15"
+    "DeviceConfigs": [
+      {
+        "Name": "FCU/EFIS Display",
+        "Description": "FCU and EFIS display with 7 Oled's",
+        "File": "Gagagu FCU-EFIS.mfmc"
       }
     ]
-  }
-  
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 16,
+    "MaxInputShifters": 4,
+    "MaxButtons": 68,
+    "MaxEncoders": 20,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 4,
+    "MaxOutputs": 40,
+    "MaxServos": 10,
+    "MaxShifters": 4,
+    "MaxSteppers": 10,
+    "MaxInputMultiplexer": 4,
+    "MaxCustomDevices": 5
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 7
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 13
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 14
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 15
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 16
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 17
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 18
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 19
+    },
+    {
+      "isAnalog": false,
+      "isPWM": false,
+      "isI2C": true,
+      "Pin": 20
+    },
+    {
+      "isAnalog": false,
+      "isPWM": false,
+      "isI2C": true,
+      "Pin": 21
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 22
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 23
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 24
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 25
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 26
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 27
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 28
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 29
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 30
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 31
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 32
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 33
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 34
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 35
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 36
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 37
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 38
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 39
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 40
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 41
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 42
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 43
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 44
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 45
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 46
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 47
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 48
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 49
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 50
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 51
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 52
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 53
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 54,
+      "Name": "A0"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 55,
+      "Name": "A1"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 56,
+      "Name": "A2"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 57,
+      "Name": "A3"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 58,
+      "Name": "A4"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 59,
+      "Name": "A5"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 60,
+      "Name": "A6"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 61,
+      "Name": "A7"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 62,
+      "Name": "A8"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 63,
+      "Name": "A9"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 64,
+      "Name": "A10"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 65,
+      "Name": "A11"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 66,
+      "Name": "A12"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 67,
+      "Name": "A13"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 68,
+      "Name": "A14"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 69,
+      "Name": "A15"
+    }
+  ]
+}


### PR DESCRIPTION
## Description of changes

Fixes the Timeout Error from the connector when flashing the firmware.

The missing setting `"TimeoutForFirmwareUpdate"` in the board.json file is added and set to 25sec.