### PR TITLE
fixed typos for Pico board and updated Readme

### DIFF
--- a/FCU_EFIS/Community/boards/gagagu_fcu_efis_mega.board.json
+++ b/FCU_EFIS/Community/boards/gagagu_fcu_efis_mega.board.json
@@ -6,7 +6,7 @@
       "115200"
     ],
     "Programmer": "wiring",
-    "Timeout": 25000
+    "Timeout": 35000
   },
   "Connection": {
     "ConnectionDelay": 2000,
@@ -16,7 +16,7 @@
     "DtrEnable": true,
     "MessageSize": 90,
     "EEPROMSize": 1496,
-    "TimeoutForFirmwareUpdate": 25000
+    "TimeoutForFirmwareUpdate": 35000
   },
   "HardwareIds": [
     "^VID_2341&PID_0010",
@@ -38,9 +38,9 @@
     "CanInstallFirmware": true,
     "CanResetBoard": true,
     "DelayAfterFirmwareUpdate": 0,
-    "FirmwareBaseName": "gagagu_fcu_efis_mega",
+    "FirmwareBaseName": "elral_gagagu_fcu_efis_mega",
     "FirmwareExtension": "hex",
-    "LatestFirmwareVersion": "0.9.2",
+    "LatestFirmwareVersion": "1.0.0",
     "FriendlyName": "Elral Gagagu FCU-EFIS Mega",
     "MobiFlightType": "Gagagu FCU/EFIS Mega",
     "ResetFirmwareFile": "reset.arduino_mega_1_0_2.hex",

--- a/FCU_EFIS/Community/boards/gagagu_fcu_efis_raspberry_pico.board.json
+++ b/FCU_EFIS/Community/boards/gagagu_fcu_efis_raspberry_pico.board.json
@@ -17,10 +17,10 @@
     "Info": {
       "CanInstallFirmware": true,
       "CanResetBoard": true,
-      "FirmwareBaseName": "gagagu_fcu_efis_raspberrypico",
+      "FirmwareBaseName": "elral_gagagu_fcu_efis_raspberrypico",
       "FirmwareExtension": "uf2",
       "FriendlyName": "Elral Gagagu FCU-EFIS RaspiPico",
-      "LatestFirmwareVersion": "0.9.2",
+      "LatestFirmwareVersion": "1.0.0",
       "MobiFlightType": "Gagagu FCU/EFIS RaspiPico",
       "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",
       "CustomDeviceTypes": [

--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ Even I2C addresses support OLED's with SH1106G driver, odd I2C addresses support
 
 ## Wiring
 ![alt_text](https://github.com/elral/MobiFlight-FCU_EFIS_OLEDs/blob/main/documents/FCU_EFIS.png)
+
+### Important note:
+If you set the I2C address to 0x71 then you need to change the Multiplexer's address too. 
+This is done by connecting the A0 PIN to the 3V3 on the Arduino board. 
+There is no need to change anything if you are using the 0x70 address though, since this is the default address of the TCA9548A board.


### PR DESCRIPTION
v1.0.0 was still using the 0.9.2 FW
wrong file name was referenced too.

Furthermore, the Readme was updated to include infomation about wiring the TCA9548A mutliplexer in case of changing the I2C address.
